### PR TITLE
feat: remove PreReleaseCheck from Production-Release use case

### DIFF
--- a/internal/usecases/helper.go
+++ b/internal/usecases/helper.go
@@ -62,22 +62,6 @@ func ReleasePrCreator(ctx context.Context, l utils.LogInterface, githubRepo gith
 	return prList, prUrls, nil
 }
 
-func PreReleaseCheck(ctx context.Context, l utils.LogInterface, githubRepo githubrepo.GithubRepo, variables *configs.Config, repoList []string) (activePrs []map[string]interface{}, err error) {
-	for _, repo := range repoList {
-		prs, err := githubRepo.ListPullRequests(ctx, variables.Owner, repo, variables.RCBranch, variables.ProductionBranch, "open")
-		if err != nil {
-			l.Error("Error listing PRs for repo %s: %v", repo, err)
-			return nil, fmt.Errorf("error listing PRs for repo %s: %v", repo, err)
-		}
-		activePrs = append(activePrs, prs...)
-	}
-	if len(activePrs) > 0 {
-		l.Error("There are active PRs: %v", activePrs)
-		return activePrs, fmt.Errorf("there are active PRs: %v", activePrs)
-	}
-	return activePrs, nil
-}
-
 func ProductionWorkflowDispatch(ctx context.Context, l utils.LogInterface, githubRepo githubrepo.GithubRepo, variables *configs.Config, repoList []string) (slackpayload string, err error) {
 	payload := map[string]interface{}{
 		"environment":     variables.Environment,

--- a/internal/usecases/release-usecase.go
+++ b/internal/usecases/release-usecase.go
@@ -56,19 +56,14 @@ func ProductionReleaseUseCase(ctx context.Context, l utils.LogInterface, client 
 	}
 	l.Info("repoList: %v", repoList)
 	var slackPayload string
-	
-	activePrs, err := PreReleaseCheck(ctx, l, githubRepo, cfg, repoList)
-	if err != nil {
-	slackPayload, err = utils.PreReleaseErrorSlackPayloadBuilder(cfg.RCVersion, activePrs)
-	if err != nil {
-	l.Fatal("Error building slack payload: %v", err)
-	}
-	} else {
-	l.Info("Staring Production Pipeline Dispatch")
+
+	// Pre-release check removed: the Hydra platform now ensures all RC -> production
+	// PRs are merged before this use case runs, so checking for open PRs here is
+	// redundant. Proceed directly to dispatching the production pipeline.
+	l.Info("Starting Production Pipeline Dispatch")
 	slackPayload, err = ProductionWorkflowDispatch(ctx, l, githubRepo, cfg, repoList)
 	if err != nil {
-	l.Fatal("Error building slack payload: %v", err)
-	}
+		l.Fatal("Error building slack payload: %v", err)
 	}
 	safeSetOutput("slack_payload", slackPayload, l)
 

--- a/internal/utils/slack-payload.go
+++ b/internal/utils/slack-payload.go
@@ -112,23 +112,6 @@ func ReleasePrCreatorSlackPayloadBuilder(rcVersion string, prList []map[string]i
 	return buildSlackPayload(headerText, sectionText, detailsTextSectionList)
 }
 
-func PreReleaseErrorSlackPayloadBuilder(rcVersion string, activePrs []map[string]interface{}) (string, error) {
-	formatFunc := func(pr map[string]interface{}) string {
-		return fmt.Sprintf(
-			"• *`%s`:  * <%s|:warning: PR-Link> -> *%s* \n",
-			pr["repository"], pr["url"], pr["state"],
-		)
-	}
-
-	sections := buildSections(activePrs, formatFunc)
-	detailsTextSectionList := buildDetailsTextSectionList(sections)
-
-	headerText := fmt.Sprintf("🚨 Pre-Release Check Failure - %s", rcVersion)
-	sectionText := "There are active PRs that need to be closed or merged before the release. Please review the list below: 📋"
-
-	return buildSlackPayload(headerText, sectionText, detailsTextSectionList)
-}
-
 func ProductionWorkflowDispatchSlackPayloadBuilder(rcVersion string, repoList []string, environment string) (string, error) {
 	formatFunc := func(repo map[string]interface{}) string {
 		return fmt.Sprintf(


### PR DESCRIPTION
## Summary
Removes the pre-release check from the **Production-Release** use case. The Hydra platform now guarantees that all RC → production PRs are merged before this use case runs, so re-verifying for open PRs here is redundant.

## Changes
- **`internal/usecases/release-usecase.go`** — `ProductionReleaseUseCase` no longer calls `PreReleaseCheck` / builds the error payload; it dispatches the production pipeline directly via `ProductionWorkflowDispatch`.
- **`internal/usecases/helper.go`** — removed the now-unused `PreReleaseCheck` helper.
- **`internal/utils/slack-payload.go`** — removed the now-unused `PreReleaseErrorSlackPayloadBuilder`.

## Verification
- `go build ./...` passes.
- `buildSections` / `buildDetailsTextSectionList` remain in use by other payload builders (not orphaned); `fmt` imports still used in both touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)