### PR TITLE
Remove Release-Creation use case

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -13,22 +13,10 @@ inputs:
     description: 'The owner of the repository'
     required: true
     default: 'owner'
-  development_branch:
-    description: 'The development branch'
-    required: true
-    default: 'development'
   production_branch:
     description: 'The default branch'
     required: true
     default: 'main'
-  pr_title:
-    description: 'The title of the pull request'
-    required: true
-    default: 'Release Candidate'
-  pr_body:
-    description: 'The body of the pull request'
-    required: true
-    default: 'This is a release candidate'
   github_token:
     description: 'The GitHub token'
     required: false

--- a/internal/configs/configuations.go
+++ b/internal/configs/configuations.go
@@ -15,9 +15,6 @@ type Config struct {
 	PrivateKey                     string
 	RCVersion                      string
 	ProductionBranch               string
-	DevelopmentBranch              string
-	PRTitle                        string
-	PRBody                         string
 	IncludeRepositories            string
 	ExcludeRepositories            string
 	ExcludeProdReleaseRepositories string
@@ -70,21 +67,8 @@ func Variables() (*Config, error) {
 		githubactions.Fatalf("production_branch is required")
 	}
 
-	developmentBranch := githubactions.GetInput("development_branch")
-	if developmentBranch == "" {
-		githubactions.Fatalf("development_branch is required")
-	}
-
 	usecase := githubactions.GetInput("use_case")
 	environment := githubactions.GetInput("environment")
-	prTitle := githubactions.GetInput("pr_title")
-	if prTitle == "" {
-		prTitle = "Release"
-	}
-	prBody := githubactions.GetInput("pr_body")
-	if prBody == "" {
-		prBody = "Release"
-	}
 
 	excludeRepositories := githubactions.GetInput("exclude_repositories")
 	includeRepositories := githubactions.GetInput("include_repositories")
@@ -108,9 +92,6 @@ func Variables() (*Config, error) {
 		InstallationID:                 installationId,
 		RCVersion:                      rcVersion,
 		ProductionBranch:               productionBranch,
-		DevelopmentBranch:              developmentBranch,
-		PRTitle:                        prTitle,
-		PRBody:                         prBody,
 		Environment:                    environment,
 		IncludeRepositories:            includeRepositories,
 		ExcludeRepositories:            excludeRepositories,

--- a/internal/usecases/githubrepo/githubrepo.go
+++ b/internal/usecases/githubrepo/githubrepo.go
@@ -16,10 +16,8 @@ import (
 type GitHubWebApis interface {
 	CreateBranch(ctx context.Context, owner string, repo string, baseBranch string, newBranch string) error
 	CreatePullRequest(ctx context.Context, owner string, repo string, fromBranch string, toBranch string, title string, body string) (prUrl string, prError string, hasConflicts bool, err error)
-	MergeBranchWithConflictPr(ctx context.Context, owner string, repo string, baseBranch string, mergeBranch string) (mergeConflictPr string, err error)
 	ListRepositories(ctx context.Context, owner string, includeRepositories string, excludeRepositories string) ([]string, error)
 	CreateRepositoryDispatches(ctx context.Context, owner string, repo string, eventType string, clientPayload map[string]interface{}) error
-	ListPullRequests(ctx context.Context, owner string, repo string, fromBranch string, toBranch string, state string) ([]map[string]interface{}, error)
 	ListWorkFlowsByRepoFileFilter(ctx context.Context, owner string, repo string, fileFilterRegex string) ([]RespWorkflow, error)
 	CreateWorkflowDispatchEventByID(ctx context.Context, owner string, repo string, workflowID int64, clientPayload map[string]interface{}) error
 	ListEpicBranches(ctx context.Context, owner string, repo string) ([]string, error)
@@ -61,59 +59,6 @@ func (g GithubRepo) CreateBranch(ctx context.Context, owner string, repo string,
 		}
 	}
 	return nil
-}
-
-func (g GithubRepo) MergeBranchWithConflictPr(ctx context.Context, owner string, repo string, baseBranch string, mergeBranch string) (mergeConflictPr string, err error) {
-	maxRetries := 5
-	retryDelay := 5 * time.Second
-	initialWait := 1 * time.Second
-
-	// Wait 1 second before the first merge attempt
-	time.Sleep(initialWait)
-
-	for attempt := 1; attempt <= maxRetries; attempt++ {
-		_, res, err := g.client.Repositories.Merge(ctx, owner, repo, &github.RepositoryMergeRequest{
-			Base:          github.String(mergeBranch),
-			Head:          github.String(baseBranch),
-			CommitMessage: github.String(fmt.Sprintf("Merge branch '%s' into '%s' on %s", mergeBranch, baseBranch, repo)),
-		})
-
-		if err == nil {
-			// Merge successful
-			g.l.Info("Merged branch %s into %s on %s", baseBranch, mergeBranch, repo)
-			return "", nil
-		}
-
-		// Handle 409 conflict (merge conflict) - don't retry, handle immediately
-		if res != nil && res.StatusCode == 409 {
-			g.l.Error("Merge conflict: %v", err)
-			prURL, _, _, err := g.CreatePullRequest(ctx, owner, repo, baseBranch, mergeBranch, "Merge conflict to "+mergeBranch, "Merge conflict to "+mergeBranch)
-			if err != nil {
-				g.l.Error("Error creating merge PR: %v", err)
-				return "", fmt.Errorf("error creating merge PR: %v", err)
-			}
-			return prURL, nil
-		}
-
-		// Handle 404 error - retry with delay
-		if res != nil && res.StatusCode == 404 {
-			if attempt < maxRetries {
-				g.l.Warn("Merge failed with 404 error (attempt %d/%d), retrying after %v: %v", attempt, maxRetries, retryDelay, err)
-				time.Sleep(retryDelay)
-				continue
-			} else {
-				g.l.Error("Merge failed with 404 error after %d attempts: %v", maxRetries, err)
-				return "", fmt.Errorf("error merging branch after %d retries: %v", maxRetries, err)
-			}
-		}
-
-		// Other errors - return immediately without retry
-		g.l.Error("Error merging branch: %v", err)
-		return "", fmt.Errorf("error merging branch: %v", err)
-	}
-
-	// Should not reach here, but handle just in case
-	return "", fmt.Errorf("error merging branch: max retries exceeded")
 }
 
 func (g GithubRepo) CreatePullRequest(ctx context.Context, owner string, repo string, fromBranch string, toBranch string, title string, body string) (prUrl string, prError string, hasConflicts bool, err error) {
@@ -261,48 +206,6 @@ func (g GithubRepo) CreateRepositoryDispatches(ctx context.Context, owner string
 	g.l.Info("Dispatched event %s to %s", eventType, repo)
 
 	return nil
-}
-
-func (g GithubRepo) ListPullRequests(ctx context.Context, owner string, repo string, fromBranch string, toBranch string, state string) ([]map[string]interface{}, error) {
-	prs, _, err := g.client.PullRequests.List(ctx, owner, repo, &github.PullRequestListOptions{
-		Base:  toBranch,
-		Head:  owner + "/" + fromBranch,
-		State: state,
-	})
-
-	if err != nil {
-		g.l.Error("Error listing PRs: %v", err)
-		return nil, fmt.Errorf("error listing PRs: %v", err)
-	}
-
-	response := make([]map[string]interface{}, 0, len(prs))
-	for _, pr := range prs {
-		if pr.Head.Ref != nil {
-			prHeadBranch := *pr.Head.Ref
-			if prHeadBranch == fromBranch {
-				g.l.Info("Listing pr from current rc branch: %v", prHeadBranch)
-				response = append(response, map[string]interface{}{
-					"url":        pr.GetHTMLURL(),
-					"id":         pr.GetID(),
-					"repository": repo,
-					"state":      pr.GetState(),
-				})
-			} else {
-				g.l.Info("skipping pr from non current rc branch %v", prHeadBranch)
-			}
-
-		} else {
-			g.l.Info("Listing pr as Head info can't be obtained")
-			response = append(response, map[string]interface{}{
-				"url":        pr.GetHTMLURL(),
-				"id":         pr.GetID(),
-				"repository": repo,
-				"state":      pr.GetState(),
-			})
-		}
-	}
-
-	return response, nil
 }
 
 func (g GithubRepo) ListWorkFlowsByRepoFileFilter(ctx context.Context, owner string, repo string, fileFilterRegex string) ([]RespWorkflow, error) {

--- a/internal/usecases/helper.go
+++ b/internal/usecases/helper.go
@@ -8,60 +8,6 @@ import (
 	"release-candidate/internal/utils"
 )
 
-func ReleasePrCreator(ctx context.Context, l utils.LogInterface, githubRepo githubrepo.GithubRepo, variables *configs.Config, repoList []string) ([]map[string]interface{}, []string, error) {
-	var prList []map[string]interface{}
-	var prUrls []string
-
-	for _, repo := range repoList {
-		if err := githubRepo.CreateBranch(ctx, variables.Owner, repo, variables.ProductionBranch, variables.RCBranch); err != nil {
-			l.Error("Error creating branch for repo %s: %v", repo, err)
-			return nil, nil, fmt.Errorf("error creating branch for repo %s: %v", repo, err)
-		}
-
-		// Check if PR already exists from RC to production branch
-		existingPrs, err := githubRepo.ListPullRequests(ctx, variables.Owner, repo, variables.RCBranch, variables.ProductionBranch, "open")
-		if err != nil {
-			l.Error("Error checking existing PRs for repo %s: %v", repo, err)
-			return nil, nil, fmt.Errorf("error checking existing PRs for repo %s: %v", repo, err)
-		}
-
-		var conflictMergePr string
-		var prUrl, prError string
-
-		if len(existingPrs) > 0 {
-			// PR already exists, skip merging development changes and use existing PR
-			l.Info("PR already exists for repo %s, skipping development merge to preserve RC stability", repo)
-			prUrl = existingPrs[0]["url"].(string)
-			prError = "PR already exists - development merge skipped"
-		} else {
-			// No existing PR, proceed with merging development and creating new PR
-			conflictMergePr, err = githubRepo.MergeBranchWithConflictPr(ctx, variables.Owner, repo, variables.DevelopmentBranch, variables.RCBranch)
-			if err != nil {
-				l.Error("Error merging branch for repo %s: %v", repo, err)
-				return nil, nil, fmt.Errorf("error merging branch for repo %s: %v", repo, err)
-			}
-
-			prUrl, prError, _, err = githubRepo.CreatePullRequest(ctx, variables.Owner, repo, variables.RCBranch, variables.ProductionBranch, variables.PRTitle, variables.PRBody)
-			if err != nil {
-				l.Error("Error creating PR for repo %s: %v", repo, err)
-				return nil, nil, fmt.Errorf("error creating PR for repo %s: %v", repo, err)
-			}
-		}
-
-		prMap := map[string]interface{}{
-			"repo":            repo,
-			"url":             prUrl,
-			"error":           prError,
-			"conflictMergePr": conflictMergePr,
-		}
-		prList = append(prList, prMap)
-		prDetails := fmt.Sprintf("%s:%s:%s\n", repo, prUrl, prError)
-		prUrls = append(prUrls, prDetails)
-	}
-
-	return prList, prUrls, nil
-}
-
 func ProductionWorkflowDispatch(ctx context.Context, l utils.LogInterface, githubRepo githubrepo.GithubRepo, variables *configs.Config, repoList []string) (slackpayload string, err error) {
 	payload := map[string]interface{}{
 		"environment":     variables.Environment,

--- a/internal/usecases/release-usecase.go
+++ b/internal/usecases/release-usecase.go
@@ -6,7 +6,6 @@ import (
 	"release-candidate/internal/configs"
 	"release-candidate/internal/usecases/githubrepo"
 	"release-candidate/internal/utils"
-	"strings"
 
 	"github.com/google/go-github/v66/github"
 	"github.com/sethvargo/go-githubactions"
@@ -19,31 +18,6 @@ func safeSetOutput(key, value string, l utils.LogInterface) {
 	} else {
 		l.Info("Not in GitHub Actions environment, skipping output set for %s", key)
 	}
-}
-
-func ReleaseCreationUseCase(ctx context.Context, l utils.LogInterface, client *github.Client, cfg *configs.Config) {
-	l.Info("Release-Creation use case")
-
-	githubRepo := githubrepo.NewGithubRepo(client, l) // init githubRepo struct
-	repoList, err := githubRepo.ListRepositories(ctx, cfg.Owner, cfg.UseCase, cfg.IncludeRepositories, cfg.ExcludeRepositories, cfg.ExcludeProdReleaseRepositories)
-	if err != nil {
-		l.Fatal("Error listing repositories: %v", err)
-	}
-
-	prList, prUrls, err := ReleasePrCreator(ctx, l, githubRepo, cfg, repoList)
-	if err != nil {
-		l.Fatal("Error creating PR: %v", err)
-	}
-
-	slackPayload, err := utils.ReleasePrCreatorSlackPayloadBuilder(cfg.RCVersion, prList)
-	if err != nil {
-		l.Fatal("Error building slack payload: %v", err)
-	}
-
-	l.Info("PR details:\n%v", prUrls)
-	safeSetOutput("pr_urls", strings.Join(prUrls, "\n"), l)
-	safeSetOutput("slack_payload", slackPayload, l)
-
 }
 
 func ProductionReleaseUseCase(ctx context.Context, l utils.LogInterface, client *github.Client, cfg *configs.Config) {

--- a/internal/utils/slack-payload.go
+++ b/internal/utils/slack-payload.go
@@ -83,35 +83,6 @@ func buildSections(items []map[string]interface{}, formatFunc func(map[string]in
 	return sections
 }
 
-func ReleasePrCreatorSlackPayloadBuilder(rcVersion string, prList []map[string]interface{}) (string, error) {
-	formatFunc := func(pr map[string]interface{}) string {
-		if pr["url"] != "" || pr["conflictMergePr"] != "" {
-			if pr["conflictMergePr"] != "" {
-				return fmt.Sprintf(
-					"• *`%s`:*  <%s|:warning: Resolve Conflict PR> -> :pray:Then rerun the RC-automation \n",
-					pr["repo"], pr["conflictMergePr"],
-				)
-			}
-			return fmt.Sprintf(
-				"• *`%s`:* <%s|:white_check_mark: PR-Link> | %s \n",
-				pr["repo"], pr["url"], pr["error"],
-			)
-		}
-		return fmt.Sprintf(
-			"• *`%s`:* %s  :white_circle:\n",
-			pr["repo"], pr["error"],
-		)
-	}
-
-	sections := buildSections(prList, formatFunc)
-	detailsTextSectionList := buildDetailsTextSectionList(sections)
-
-	headerText := fmt.Sprintf("🚀 Release Candidate Branches for %s", rcVersion)
-	sectionText := "Below is a compact list of RC branch PR details for review. 📋"
-
-	return buildSlackPayload(headerText, sectionText, detailsTextSectionList)
-}
-
 func ProductionWorkflowDispatchSlackPayloadBuilder(rcVersion string, repoList []string, environment string) (string, error) {
 	formatFunc := func(repo map[string]interface{}) string {
 		return fmt.Sprintf(

--- a/main.go
+++ b/main.go
@@ -30,9 +30,6 @@ func main() {
 	}
 
 	switch config.UseCase {
-	case "Release-Creation":
-		l.Info("Release-Creation use case")
-		usecases.ReleaseCreationUseCase(context.Background(), l, githubClient, config)
 	case "Production-Release":
 		l.Info("Production-Release use case")
 		usecases.ProductionReleaseUseCase(context.Background(), l, githubClient, config)


### PR DESCRIPTION
## What
Removes the **Release-Creation** use case from the release-wave action. RC branch/PR creation has moved to the Hydra platform, so this path is no longer used.

## Changes
- Drop the `Release-Creation` switch case in `main.go`
- Remove `ReleaseCreationUseCase` and its `ReleasePrCreator` helper
- Remove `ReleasePrCreatorSlackPayloadBuilder` Slack payload builder
- Remove `MergeBranchWithConflictPr` and `ListPullRequests` `githubrepo` methods (used only by `ReleasePrCreator`) plus their interface declarations
- Remove the now-unused `development_branch` / `pr_title` / `pr_body` action inputs and their `DevelopmentBranch` / `PRTitle` / `PRBody` `Config` fields

## Unaffected
`Production-Release` and `Main-To-Epic-Sync` use cases, and shared helpers (`CreateBranch`, `CreatePullRequest`, `ListRepositories`, `ProductionWorkflowDispatch`).

## Companion change
The caller workflow in **kube-deployment** (`.github/workflows/release-candidate.yml`) is updated in a separate PR to stop passing the removed inputs and drop the `Release-Creation` option. These should land together.

## Verification
- `go build ./...` ✅
- `go vet ./...` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)